### PR TITLE
`ResponseEntity` to JAX-RS `Response` migration

### DIFF
--- a/src/main/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponse.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponse.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.spring;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ResponseEntityToJaxRsResponse extends Recipe {
+
+    public static final String RESPONSE_ENTITY_FQN = "org.springframework.http.ResponseEntity";
+    public static final String RESPONSE_FQN = "jakarta.ws.rs.core.Response";
+    public static final String HTTP_STATUS_FQN = "org.springframework.http.HttpStatus";
+
+    private static final MethodMatcher RESPONSE_ENTITY_OK = new MethodMatcher("org.springframework.http.ResponseEntity ok(..)");
+    private static final MethodMatcher RESPONSE_ENTITY_NOT_FOUND = new MethodMatcher("org.springframework.http.ResponseEntity notFound()");
+    private static final MethodMatcher RESPONSE_ENTITY_STATUS = new MethodMatcher("org.springframework.http.ResponseEntity status(..)");
+    private static final MethodMatcher BODY_METHOD = new MethodMatcher("org.springframework.http.ResponseEntity$* body(..)");
+    private static final MethodMatcher BUILD_METHOD = new MethodMatcher("org.springframework.http.ResponseEntity$* build()");
+
+    @Override
+    public String getDisplayName() {
+        return "Convert Spring ResponseEntity to JAX-RS Response";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms Spring ResponseEntity patterns to JAX-RS Response API equivalents.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(RESPONSE_ENTITY_FQN, false),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    private final ChangeType changeType = new ChangeType(RESPONSE_ENTITY_FQN, RESPONSE_FQN, false);
+
+                    @Override
+                    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                        J.CompilationUnit c = super.visitCompilationUnit(cu, ctx);
+                        maybeRemoveImport(RESPONSE_ENTITY_FQN);
+                        maybeRemoveImport(HTTP_STATUS_FQN);
+                        maybeAddImport(RESPONSE_FQN);
+                        return (J.CompilationUnit) changeType.getVisitor().visit(c, ctx);
+                    }
+
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+
+                        if (RESPONSE_ENTITY_OK.matches(m)) {
+                            if (m.getArguments().isEmpty()) {
+                                return JavaTemplate.builder("Response.ok()")
+                                        .imports(RESPONSE_FQN)
+                                        .contextSensitive()
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                        .build()
+                                        .apply(getCursor(), m.getCoordinates().replace());
+                            } else {
+                                return JavaTemplate.builder("Response.ok(#{any()})")
+                                        .imports(RESPONSE_FQN)
+                                        .contextSensitive()
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                        .build()
+                                        .apply(getCursor(), m.getCoordinates().replace(), m.getArguments().get(0));
+                            }
+                        }
+
+                        if (RESPONSE_ENTITY_NOT_FOUND.matches(m)) {
+                            return JavaTemplate.builder("Response.status(Response.Status.NOT_FOUND)")
+                                    .imports(RESPONSE_FQN)
+                                    .contextSensitive()
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                    .build()
+                                    .apply(getCursor(), m.getCoordinates().replace());
+                        }
+
+                        if (RESPONSE_ENTITY_STATUS.matches(m) && !m.getArguments().isEmpty()) {
+                            String statusMapping = mapHttpStatusToResponseStatus(m.getArguments().get(0));
+                            if (statusMapping != null) {
+                                return JavaTemplate.builder("Response.status(" + statusMapping + ")")
+                                        .imports(RESPONSE_FQN)
+                                        .contextSensitive()
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                        .build()
+                                        .apply(getCursor(), m.getCoordinates().replace());
+                            }
+                        }
+
+                        if (BODY_METHOD.matches(m)) {
+                            return JavaTemplate.builder("#{any()}.entity(#{any()})")
+                                    .contextSensitive()
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                    .build()
+                                    .apply(getCursor(), m.getCoordinates().replace(),
+                                           m.getSelect(), m.getArguments().get(0));
+                        }
+
+                        return m;
+                    }
+
+                    private @Nullable String mapHttpStatusToResponseStatus(Expression statusExpr) {
+                        if (statusExpr instanceof J.FieldAccess) {
+                            J.FieldAccess fieldAccess = (J.FieldAccess) statusExpr;
+                            String statusName = fieldAccess.getSimpleName();
+
+                            switch (statusName) {
+                                case "CREATED":
+                                case "NO_CONTENT":
+                                case "NOT_FOUND":
+                                case "BAD_REQUEST":
+                                case "UNAUTHORIZED":
+                                case "FORBIDDEN":
+                                case "INTERNAL_SERVER_ERROR":
+                                    return "Response.Status." + statusName;
+                                default:
+                                    return null;
+                            }
+                        }
+                        return null;
+                    }
+                });
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponse.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponse.java
@@ -39,7 +39,6 @@ public class ResponseEntityToJaxRsResponse extends Recipe {
     private static final MethodMatcher RESPONSE_ENTITY_NOT_FOUND = new MethodMatcher("org.springframework.http.ResponseEntity notFound()");
     private static final MethodMatcher RESPONSE_ENTITY_STATUS = new MethodMatcher("org.springframework.http.ResponseEntity status(..)");
     private static final MethodMatcher BODY_METHOD = new MethodMatcher("org.springframework.http.ResponseEntity$* body(..)");
-    private static final MethodMatcher BUILD_METHOD = new MethodMatcher("org.springframework.http.ResponseEntity$* build()");
 
     @Override
     public String getDisplayName() {
@@ -73,14 +72,12 @@ public class ResponseEntityToJaxRsResponse extends Recipe {
                     if (m.getArguments().isEmpty()) {
                         return JavaTemplate.builder("Response.ok()")
                                 .imports(RESPONSE_FQN)
-                                .contextSensitive()
                                 .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
                                 .build()
                                 .apply(getCursor(), m.getCoordinates().replace());
                     }
                     return JavaTemplate.builder("Response.ok(#{any()})")
                             .imports(RESPONSE_FQN)
-                            .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
                             .build()
                             .apply(getCursor(), m.getCoordinates().replace(), m.getArguments().get(0));
@@ -89,7 +86,6 @@ public class ResponseEntityToJaxRsResponse extends Recipe {
                 if (RESPONSE_ENTITY_NOT_FOUND.matches(m)) {
                     return JavaTemplate.builder("Response.status(Response.Status.NOT_FOUND)")
                             .imports(RESPONSE_FQN)
-                            .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
                             .build()
                             .apply(getCursor(), m.getCoordinates().replace());
@@ -100,7 +96,6 @@ public class ResponseEntityToJaxRsResponse extends Recipe {
                     if (statusMapping != null) {
                         return JavaTemplate.builder("Response.status(" + statusMapping + ")")
                                 .imports(RESPONSE_FQN)
-                                .contextSensitive()
                                 .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
                                 .build()
                                 .apply(getCursor(), m.getCoordinates().replace());
@@ -109,7 +104,6 @@ public class ResponseEntityToJaxRsResponse extends Recipe {
 
                 if (BODY_METHOD.matches(m)) {
                     return JavaTemplate.builder("#{any()}.entity(#{any()})")
-                            .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
                             .build()
                             .apply(getCursor(),

--- a/src/main/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponse.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponse.java
@@ -22,16 +22,10 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeUtils;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -49,105 +43,103 @@ public class ResponseEntityToJaxRsResponse extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Convert Spring ResponseEntity to JAX-RS Response";
+        return "Convert Spring `ResponseEntity` to JAX-RS `Response`";
     }
 
     @Override
     public String getDescription() {
-        return "Transforms Spring ResponseEntity patterns to JAX-RS Response API equivalents.";
+        return "Transforms Spring `ResponseEntity` patterns to JAX-RS `Response` API equivalents.";
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(
-                new UsesType<>(RESPONSE_ENTITY_FQN, false),
-                new JavaIsoVisitor<ExecutionContext>() {
-                    private final ChangeType changeType = new ChangeType(RESPONSE_ENTITY_FQN, RESPONSE_FQN, false);
+        return Preconditions.check(new UsesType<>(RESPONSE_ENTITY_FQN, false), new JavaIsoVisitor<ExecutionContext>() {
+            private final ChangeType changeType = new ChangeType(RESPONSE_ENTITY_FQN, RESPONSE_FQN, false);
 
-                    @Override
-                    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                        J.CompilationUnit c = super.visitCompilationUnit(cu, ctx);
-                        maybeRemoveImport(RESPONSE_ENTITY_FQN);
-                        maybeRemoveImport(HTTP_STATUS_FQN);
-                        maybeAddImport(RESPONSE_FQN);
-                        return (J.CompilationUnit) changeType.getVisitor().visit(c, ctx);
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                J.CompilationUnit c = super.visitCompilationUnit(cu, ctx);
+                maybeRemoveImport(RESPONSE_ENTITY_FQN);
+                maybeRemoveImport(HTTP_STATUS_FQN);
+                maybeAddImport(RESPONSE_FQN);
+                return (J.CompilationUnit) changeType.getVisitor().visitNonNull(c, ctx);
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+
+                if (RESPONSE_ENTITY_OK.matches(m)) {
+                    if (m.getArguments().isEmpty()) {
+                        return JavaTemplate.builder("Response.ok()")
+                                .imports(RESPONSE_FQN)
+                                .contextSensitive()
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                .build()
+                                .apply(getCursor(), m.getCoordinates().replace());
                     }
+                    return JavaTemplate.builder("Response.ok(#{any()})")
+                            .imports(RESPONSE_FQN)
+                            .contextSensitive()
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                            .build()
+                            .apply(getCursor(), m.getCoordinates().replace(), m.getArguments().get(0));
+                }
 
-                    @Override
-                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                        J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                if (RESPONSE_ENTITY_NOT_FOUND.matches(m)) {
+                    return JavaTemplate.builder("Response.status(Response.Status.NOT_FOUND)")
+                            .imports(RESPONSE_FQN)
+                            .contextSensitive()
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                            .build()
+                            .apply(getCursor(), m.getCoordinates().replace());
+                }
 
-                        if (RESPONSE_ENTITY_OK.matches(m)) {
-                            if (m.getArguments().isEmpty()) {
-                                return JavaTemplate.builder("Response.ok()")
-                                        .imports(RESPONSE_FQN)
-                                        .contextSensitive()
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                                        .build()
-                                        .apply(getCursor(), m.getCoordinates().replace());
-                            } else {
-                                return JavaTemplate.builder("Response.ok(#{any()})")
-                                        .imports(RESPONSE_FQN)
-                                        .contextSensitive()
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                                        .build()
-                                        .apply(getCursor(), m.getCoordinates().replace(), m.getArguments().get(0));
-                            }
-                        }
-
-                        if (RESPONSE_ENTITY_NOT_FOUND.matches(m)) {
-                            return JavaTemplate.builder("Response.status(Response.Status.NOT_FOUND)")
-                                    .imports(RESPONSE_FQN)
-                                    .contextSensitive()
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                                    .build()
-                                    .apply(getCursor(), m.getCoordinates().replace());
-                        }
-
-                        if (RESPONSE_ENTITY_STATUS.matches(m) && !m.getArguments().isEmpty()) {
-                            String statusMapping = mapHttpStatusToResponseStatus(m.getArguments().get(0));
-                            if (statusMapping != null) {
-                                return JavaTemplate.builder("Response.status(" + statusMapping + ")")
-                                        .imports(RESPONSE_FQN)
-                                        .contextSensitive()
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                                        .build()
-                                        .apply(getCursor(), m.getCoordinates().replace());
-                            }
-                        }
-
-                        if (BODY_METHOD.matches(m)) {
-                            return JavaTemplate.builder("#{any()}.entity(#{any()})")
-                                    .contextSensitive()
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                                    .build()
-                                    .apply(getCursor(), m.getCoordinates().replace(),
-                                           m.getSelect(), m.getArguments().get(0));
-                        }
-
-                        return m;
+                if (RESPONSE_ENTITY_STATUS.matches(m) && !m.getArguments().isEmpty()) {
+                    String statusMapping = mapHttpStatusToResponseStatus(m.getArguments().get(0));
+                    if (statusMapping != null) {
+                        return JavaTemplate.builder("Response.status(" + statusMapping + ")")
+                                .imports(RESPONSE_FQN)
+                                .contextSensitive()
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                                .build()
+                                .apply(getCursor(), m.getCoordinates().replace());
                     }
+                }
 
-                    private @Nullable String mapHttpStatusToResponseStatus(Expression statusExpr) {
-                        if (statusExpr instanceof J.FieldAccess) {
-                            J.FieldAccess fieldAccess = (J.FieldAccess) statusExpr;
-                            String statusName = fieldAccess.getSimpleName();
+                if (BODY_METHOD.matches(m)) {
+                    return JavaTemplate.builder("#{any()}.entity(#{any()})")
+                            .contextSensitive()
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                            .build()
+                            .apply(getCursor(),
+                                    m.getCoordinates().replace(),
+                                    m.getSelect(),
+                                    m.getArguments().get(0));
+                }
 
-                            switch (statusName) {
-                                case "CREATED":
-                                case "NO_CONTENT":
-                                case "NOT_FOUND":
-                                case "BAD_REQUEST":
-                                case "UNAUTHORIZED":
-                                case "FORBIDDEN":
-                                case "INTERNAL_SERVER_ERROR":
-                                    return "Response.Status." + statusName;
-                                default:
-                                    return null;
-                            }
-                        }
-                        return null;
+                return m;
+            }
+
+            private @Nullable String mapHttpStatusToResponseStatus(Expression statusExpr) {
+                if (statusExpr instanceof J.FieldAccess) {
+                    J.FieldAccess fieldAccess = (J.FieldAccess) statusExpr;
+                    String statusName = fieldAccess.getSimpleName();
+                    switch (statusName) {
+                        case "CREATED":
+                        case "NO_CONTENT":
+                        case "NOT_FOUND":
+                        case "BAD_REQUEST":
+                        case "UNAUTHORIZED":
+                        case "FORBIDDEN":
+                        case "INTERNAL_SERVER_ERROR":
+                            return "Response.Status." + statusName;
+                        default:
+                            return null;
                     }
-                });
+                }
+                return null;
+            }
+        });
     }
 }

--- a/src/main/resources/META-INF/rewrite/spring-boot-to-quarkus.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-to-quarkus.yml
@@ -40,6 +40,7 @@ recipeList:
   - org.openrewrite.quarkus.spring.RemoveSpringBootApplication
   - org.openrewrite.quarkus.spring.EnableAnnotationsToQuarkusDependencies
   - org.openrewrite.quarkus.spring.AddSpringCompatibilityExtensions
+  - org.openrewrite.quarkus.spring.ResponseEntityToJaxRsResponse
   - org.openrewrite.quarkus.spring.StereotypeAnnotationsToCDI
   - org.openrewrite.quarkus.spring.ValueToCdiConfigProperty
   - org.openrewrite.quarkus.spring.WebToJaxRs

--- a/src/test/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponseTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponseTest.java
@@ -34,7 +34,7 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void convertResponseEntityOk() {
+    void ok() {
         rewriteRun(
           //language=java
           java(
@@ -44,9 +44,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @GetMapping("/products/{id}")
-                  public ResponseEntity<Product> getProduct() {
+                  ResponseEntity<Product> getProduct() {
                       Product product = new Product();
                       return ResponseEntity.ok(product);
                   }
@@ -62,9 +62,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @GetMapping("/products/{id}")
-                  public Response<Product> getProduct() {
+                  Response<Product> getProduct() {
                       Product product = new Product();
                       return Response.ok(product);
                   }
@@ -79,7 +79,7 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
     }
 
     @Test
-    void convertResponseEntityNotFound() {
+    void notFound() {
         rewriteRun(
           //language=java
           java(
@@ -89,9 +89,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @GetMapping("/products/{id}")
-                  public ResponseEntity<Product> getProduct() {
+                  ResponseEntity<Product> getProduct() {
                       return ResponseEntity.notFound().build();
                   }
               }
@@ -106,9 +106,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @GetMapping("/products/{id}")
-                  public Response<Product> getProduct() {
+                  Response<Product> getProduct() {
                       return Response.status(Response.Status.NOT_FOUND).build();
                   }
               }
@@ -122,7 +122,7 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
     }
 
     @Test
-    void convertResponseEntityStatus() {
+    void status() {
         rewriteRun(
           //language=java
           java(
@@ -133,9 +133,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @PostMapping("/products")
-                  public ResponseEntity<Product> createProduct() {
+                  ResponseEntity<Product> createProduct() {
                       Product product = new Product();
                       return ResponseEntity.status(HttpStatus.CREATED).body(product);
                   }
@@ -151,9 +151,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @PostMapping("/products")
-                  public Response<Product> createProduct() {
+                  Response<Product> createProduct() {
                       Product product = new Product();
                       return Response.status(Response.Status.CREATED).entity(product);
                   }
@@ -168,7 +168,7 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
     }
 
     @Test
-    void convertResponseEntityEmptyOk() {
+    void emptyOk() {
         rewriteRun(
           spec -> spec.afterTypeValidationOptions(TypeValidation.none()),
           //language=java
@@ -179,9 +179,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @GetMapping("/products")
-                  public ResponseEntity<Void> getProducts() {
+                  ResponseEntity<Void> getProducts() {
                       return ResponseEntity.ok().build();
                   }
               }
@@ -192,9 +192,9 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
+              class ProductController {
                   @GetMapping("/products")
-                  public Response<Void> getProducts() {
+                  Response<Void> getProducts() {
                       return Response.ok().build();
                   }
               }
@@ -204,7 +204,7 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
     }
 
     @Test
-    void convertMultipleStatusCodes() {
+    void badRequestAndNoContent() {
         rewriteRun(
           //language=java
           java(
@@ -214,12 +214,12 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
-                  public ResponseEntity<String> badRequest() {
+              class ProductController {
+                  ResponseEntity<String> badRequest() {
                       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("error");
                   }
 
-                  public ResponseEntity<Void> noContent() {
+                  ResponseEntity<Void> noContent() {
                       return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
                   }
               }
@@ -229,12 +229,12 @@ class ResponseEntityToJaxRsResponseTest implements RewriteTest {
               import org.springframework.web.bind.annotation.RestController;
 
               @RestController
-              public class ProductController {
-                  public Response<String> badRequest() {
+              class ProductController {
+                  Response<String> badRequest() {
                       return Response.status(Response.Status.BAD_REQUEST).entity("error");
                   }
 
-                  public Response<Void> noContent() {
+                  Response<Void> noContent() {
                       return Response.status(Response.Status.NO_CONTENT).build();
                   }
               }

--- a/src/test/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponseTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/ResponseEntityToJaxRsResponseTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.spring;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ResponseEntityToJaxRsResponseTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ResponseEntityToJaxRsResponse())
+          .parser(JavaParser.fromJavaVersion().classpath("spring-web", "spring-context"));
+    }
+
+    @DocumentExample
+    @Test
+    void convertResponseEntityOk() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.GetMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @GetMapping("/products/{id}")
+                  public ResponseEntity<Product> getProduct() {
+                      Product product = new Product();
+                      return ResponseEntity.ok(product);
+                  }
+              }
+
+              class Product {
+                  String name;
+              }
+              """,
+            """
+              import jakarta.ws.rs.core.Response;
+              import org.springframework.web.bind.annotation.GetMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @GetMapping("/products/{id}")
+                  public Response<Product> getProduct() {
+                      Product product = new Product();
+                      return Response.ok(product);
+                  }
+              }
+
+              class Product {
+                  String name;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertResponseEntityNotFound() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.GetMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @GetMapping("/products/{id}")
+                  public ResponseEntity<Product> getProduct() {
+                      return ResponseEntity.notFound().build();
+                  }
+              }
+
+              class Product {
+                  String name;
+              }
+              """,
+            """
+              import jakarta.ws.rs.core.Response;
+              import org.springframework.web.bind.annotation.GetMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @GetMapping("/products/{id}")
+                  public Response<Product> getProduct() {
+                      return Response.status(Response.Status.NOT_FOUND).build();
+                  }
+              }
+
+              class Product {
+                  String name;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertResponseEntityStatus() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpStatus;
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.PostMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @PostMapping("/products")
+                  public ResponseEntity<Product> createProduct() {
+                      Product product = new Product();
+                      return ResponseEntity.status(HttpStatus.CREATED).body(product);
+                  }
+              }
+
+              class Product {
+                  String name;
+              }
+              """,
+            """
+              import jakarta.ws.rs.core.Response;
+              import org.springframework.web.bind.annotation.PostMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @PostMapping("/products")
+                  public Response<Product> createProduct() {
+                      Product product = new Product();
+                      return Response.status(Response.Status.CREATED).entity(product);
+                  }
+              }
+
+              class Product {
+                  String name;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertResponseEntityEmptyOk() {
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.GetMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @GetMapping("/products")
+                  public ResponseEntity<Void> getProducts() {
+                      return ResponseEntity.ok().build();
+                  }
+              }
+              """,
+            """
+              import jakarta.ws.rs.core.Response;
+              import org.springframework.web.bind.annotation.GetMapping;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  @GetMapping("/products")
+                  public Response<Void> getProducts() {
+                      return Response.ok().build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertMultipleStatusCodes() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpStatus;
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  public ResponseEntity<String> badRequest() {
+                      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("error");
+                  }
+
+                  public ResponseEntity<Void> noContent() {
+                      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+                  }
+              }
+              """,
+            """
+              import jakarta.ws.rs.core.Response;
+              import org.springframework.web.bind.annotation.RestController;
+
+              @RestController
+              public class ProductController {
+                  public Response<String> badRequest() {
+                      return Response.status(Response.Status.BAD_REQUEST).entity("error");
+                  }
+
+                  public Response<Void> noContent() {
+                      return Response.status(Response.Status.NO_CONTENT).build();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Implements migration of Spring ResponseEntity patterns to JAX-RS Response API equivalents.

Transformations:
- `ResponseEntity.ok()` → `Response.ok()`
- `ResponseEntity.notFound()` → `Response.status(Response.Status.NOT_FOUND)`
- `ResponseEntity.status(HttpStatus.XXX)` → `Response.status(Response.Status.XXX)`
- `.body(entity)` → `.entity(entity)`
- Return types: `ResponseEntity<T>` → `Response<T>`

Status mapping:
Maps Spring `HttpStatus` constants to JAX-RS `Response.Status` equivalents (`CREATED, NO_CONTENT, NOT_FOUND, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, INTERNAL_SERVER_ERROR`).
