### PR TITLE
`CustomizeQuarkusVersionTest` fix for quarkus BOM 3.31.4

### DIFF
--- a/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusVersionTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusVersionTest.java
@@ -45,7 +45,7 @@ class CustomizeQuarkusVersionTest implements RewriteTest {
                           <dependency>
                               <groupId>io.quarkus.platform</groupId>
                               <artifactId>quarkus-bom</artifactId>
-                              <version>3.31.3</version>
+                              <version>3.31.4</version>
                               <type>pom</type>
                               <scope>import</scope>
                           </dependency>


### PR DESCRIPTION
**What**:
Update one of the tests to a 3.31.4 of quarkus BOM

**Why**:
Fix broken CI