### PR TITLE
Use pattern matching in CustomizeQuarkusVersionTest

### DIFF
--- a/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusVersionTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusVersionTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class CustomizeQuarkusVersionTest implements RewriteTest {
@@ -45,16 +46,17 @@ class CustomizeQuarkusVersionTest implements RewriteTest {
                           <dependency>
                               <groupId>io.quarkus.platform</groupId>
                               <artifactId>quarkus-bom</artifactId>
-                              <version>3.31.4</version>
+                              <version>2.16.12.Final</version>
                               <type>pom</type>
                               <scope>import</scope>
                           </dependency>
                       </dependencies>
                   </dependencyManagement>
               </project>
-              """
-            // Note: The actual version update depends on what 3.x resolves to
-            // This test validates the recipe is properly configured
+              """,
+            spec -> spec.after(actual -> assertThat(actual)
+              .containsPattern("<artifactId>quarkus-bom</artifactId>\\s*<version>3\\.\\d+\\.\\d+</version>")
+              .actual())
           )
         );
     }


### PR DESCRIPTION
## Summary
- Use `afterSpec` with `containsPattern` to verify the quarkus-bom version matches a `3.x.y` pattern instead of hardcoding a specific version
- Change the before state to use `2.16.12.Final` so the upgrade to 3.x is actually exercised
- Prevents the test from breaking each time a new Quarkus version is released (as happened with 3.31.3 → 3.31.4)

## Test plan
- [x] `CustomizeQuarkusVersionTest` passes
- [x] Full test suite passes (1 pre-existing failure in `MigrateDatabaseDriversTest.migrateRuntimeScopeDependency` unrelated to this change; note that that test is already disabled in CI)