### PR TITLE
Fix untyped template substitution in WebToJaxRs (#74)

### DIFF
--- a/src/main/java/org/openrewrite/quarkus/spring/WebToJaxRs.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/WebToJaxRs.java
@@ -280,7 +280,7 @@ public class WebToJaxRs extends Recipe {
                     String newAnn = "@PathParam";
                     Object[] args = new Object[0];
                     if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
-                        newAnn = "@PathParam(#{})";
+                        newAnn = "@PathParam(#{any()})";
                         args = ann.getArguments().toArray();
                     }
                     return JavaTemplate.builder(newAnn)
@@ -297,7 +297,7 @@ public class WebToJaxRs extends Recipe {
                     String newAnn = "@QueryParam";
                     Object[] args = new Object[0];
                     if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
-                        newAnn = "@QueryParam(#{})";
+                        newAnn = "@QueryParam(#{any()})";
                         args = ann.getArguments().toArray();
                     }
                     return JavaTemplate.builder(newAnn)
@@ -314,7 +314,7 @@ public class WebToJaxRs extends Recipe {
                     String newAnn = "@HeaderParam";
                     Object[] args = new Object[0];
                     if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
-                        newAnn = "@HeaderParam(#{})";
+                        newAnn = "@HeaderParam(#{any()})";
                         args = ann.getArguments().toArray();
                     }
                     return JavaTemplate.builder(newAnn)


### PR DESCRIPTION
## Summary

Fixed an `IllegalArgumentException` that occurred when converting Spring parameter annotations (`@PathVariable`, `@RequestParam`, `@RequestHeader`) to their JAX-RS equivalents (`@PathParam`, `@QueryParam`, `@HeaderParam`).

## Changes

Changed three JavaTemplate substitutions from untyped `#{}` to typed `#{any()}` in `WebToJaxRs.java`. This matches the pattern already used elsewhere in the file and resolves the template parameter type checking error.

## Test Results

All existing `WebToJaxRsTest` tests pass successfully.