### PR TITLE
Fix @PathParam losing parameter name (Issue #76)

### DIFF
--- a/src/main/java/org/openrewrite/quarkus/spring/WebToJaxRs.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/WebToJaxRs.java
@@ -275,57 +275,40 @@ public class WebToJaxRs extends Recipe {
                 if (PATH_VARIABLE_MATCHER.matches(ann)) {
                     maybeRemoveImport("org.springframework.web.bind.annotation.PathVariable");
                     maybeAddImport("jakarta.ws.rs.PathParam");
-
-                    // Keep arguments if present
-                    String newAnn = "@PathParam";
-                    Object[] args = new Object[0];
-                    if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
-                        newAnn = "@PathParam(#{any()})";
-                        args = ann.getArguments().toArray();
-                    }
-                    return JavaTemplate.builder(newAnn)
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                            .imports("jakarta.ws.rs.PathParam")
-                            .build()
-                            .apply(getCursor(), ann.getCoordinates().replace(), args);
+                    return convertParamAnnotation(ann, "PathParam", (J.VariableDeclarations) parent, ctx);
                 }
                 if (REQUEST_PARAM_MATCHER.matches(ann)) {
                     maybeRemoveImport("org.springframework.web.bind.annotation.RequestParam");
                     maybeAddImport("jakarta.ws.rs.QueryParam");
-
-                    // Keep arguments if present
-                    String newAnn = "@QueryParam";
-                    Object[] args = new Object[0];
-                    if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
-                        newAnn = "@QueryParam(#{any()})";
-                        args = ann.getArguments().toArray();
-                    }
-                    return JavaTemplate.builder(newAnn)
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                            .imports("jakarta.ws.rs.QueryParam")
-                            .build()
-                            .apply(getCursor(), ann.getCoordinates().replace(), args);
+                    return convertParamAnnotation(ann, "QueryParam", (J.VariableDeclarations) parent, ctx);
                 }
                 if (REQUEST_HEADER_MATCHER.matches(ann)) {
                     maybeRemoveImport("org.springframework.web.bind.annotation.RequestHeader");
                     maybeAddImport("jakarta.ws.rs.HeaderParam");
-
-                    // Keep arguments if present
-                    String newAnn = "@HeaderParam";
-                    Object[] args = new Object[0];
-                    if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
-                        newAnn = "@HeaderParam(#{any()})";
-                        args = ann.getArguments().toArray();
-                    }
-                    return JavaTemplate.builder(newAnn)
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
-                            .imports("jakarta.ws.rs.HeaderParam")
-                            .build()
-                            .apply(getCursor(), ann.getCoordinates().replace(), args);
+                    return convertParamAnnotation(ann, "HeaderParam", (J.VariableDeclarations) parent, ctx);
                 }
             }
 
             return ann;
+        }
+
+        private J.Annotation convertParamAnnotation(J.Annotation ann, String jaxRsAnnotation, J.VariableDeclarations varDecls, ExecutionContext ctx) {
+            String template;
+            Object[] args;
+            if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
+                template = "@" + jaxRsAnnotation + "(#{any()})";
+                args = ann.getArguments().toArray();
+            } else {
+                // Infer name from the variable declaration
+                String paramName = varDecls.getVariables().get(0).getSimpleName();
+                template = "@" + jaxRsAnnotation + "(\"" + paramName + "\")";
+                args = new Object[0];
+            }
+            return JavaTemplate.builder(template)
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.ws.rs-api"))
+                    .imports("jakarta.ws.rs." + jaxRsAnnotation)
+                    .build()
+                    .apply(getCursor(), ann.getCoordinates().replace(), args);
         }
 
         private J.Annotation convertHttpMethodMapping(J.Annotation ann, String springMapping, String jaxRsMethod, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/quarkus/spring/WebToJaxRs.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/WebToJaxRs.java
@@ -293,11 +293,13 @@ public class WebToJaxRs extends Recipe {
         }
 
         private J.Annotation convertParamAnnotation(J.Annotation ann, String jaxRsAnnotation, J.VariableDeclarations varDecls, ExecutionContext ctx) {
+            // Extract explicit value/name attribute from the annotation
+            Expression value = extractAttributeValue(ann, "value", "name");
             String template;
             Object[] args;
-            if (ann.getArguments() != null && !ann.getArguments().isEmpty()) {
+            if (value != null) {
                 template = "@" + jaxRsAnnotation + "(#{any()})";
-                args = ann.getArguments().toArray();
+                args = new Object[]{value};
             } else {
                 // Infer name from the variable declaration
                 String paramName = varDecls.getVariables().get(0).getSimpleName();

--- a/src/test/java/org/openrewrite/quarkus/spring/WebToJaxRsTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/WebToJaxRsTest.java
@@ -202,19 +202,19 @@ class WebToJaxRsTest implements RewriteTest {
 
                   @PUT
                   @Path("/users/{id}")
-                  public String updateUser(@PathParam Long id) {
+                  public String updateUser(@PathParam("id") Long id) {
                       return "updated";
                   }
 
                   @DELETE
                   @Path("/users/{id}")
-                  public String deleteUser(@PathParam Long id) {
+                  public String deleteUser(@PathParam("id") Long id) {
                       return "deleted";
                   }
 
                   @PATCH
                   @Path("/users/{id}")
-                  public String patchUser(@PathParam Long id) {
+                  public String patchUser(@PathParam("id") Long id) {
                       return "patched";
                   }
               }
@@ -260,6 +260,43 @@ class WebToJaxRsTest implements RewriteTest {
     }
 
     @Test
+    void convertPathVariableWithoutExplicitValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.web.bind.annotation.*;
+
+              @RestController
+              @RequestMapping("/api")
+              public class GreetingController {
+
+                  @GetMapping("/hello/{name}")
+                  public String hello(@PathVariable String name) {
+                      return "Hello, " + name + "!";
+                  }
+              }
+              """,
+            """
+              import jakarta.ws.rs.GET;
+              import jakarta.ws.rs.Path;
+              import jakarta.ws.rs.PathParam;
+
+              @Path("/api")
+              public class GreetingController {
+
+                  @GET
+                  @Path("/hello/{name}")
+                  public String hello(@PathParam("name") String name) {
+                      return "Hello, " + name + "!";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void convertRequestParam() {
         rewriteRun(
           //language=java
@@ -289,6 +326,78 @@ class WebToJaxRsTest implements RewriteTest {
                   @Path("/users")
                   public String getUsers(@QueryParam("page") int page,
                                         @QueryParam("size") int size) {
+                      return "users";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertRequestParamWithoutExplicitValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.web.bind.annotation.*;
+
+              @RestController
+              public class UserController {
+
+                  @GetMapping("/users")
+                  public String getUsers(@RequestParam int page) {
+                      return "users";
+                  }
+              }
+              """,
+            """
+              import jakarta.ws.rs.GET;
+              import jakarta.ws.rs.Path;
+              import jakarta.ws.rs.QueryParam;
+
+              @Path("")
+              public class UserController {
+
+                  @GET
+                  @Path("/users")
+                  public String getUsers(@QueryParam("page") int page) {
+                      return "users";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertRequestHeaderWithoutExplicitValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.web.bind.annotation.*;
+
+              @RestController
+              public class UserController {
+
+                  @GetMapping("/users")
+                  public String getUsers(@RequestHeader String authorization) {
+                      return "users";
+                  }
+              }
+              """,
+            """
+              import jakarta.ws.rs.GET;
+              import jakarta.ws.rs.HeaderParam;
+              import jakarta.ws.rs.Path;
+
+              @Path("")
+              public class UserController {
+
+                  @GET
+                  @Path("/users")
+                  public String getUsers(@HeaderParam("authorization") String authorization) {
                       return "users";
                   }
               }
@@ -469,7 +578,7 @@ class WebToJaxRsTest implements RewriteTest {
 
                   @GET
                   @Path("/users/{id}")
-                  public String getUser(@PathParam Long id) {
+                  public String getUser(@PathParam("id") Long id) {
                       return "user";
                   }
 
@@ -481,13 +590,13 @@ class WebToJaxRsTest implements RewriteTest {
 
                   @PUT
                   @Path("/users/{id}")
-                  public String updateUser(@PathParam Long id, User user) {
+                  public String updateUser(@PathParam("id") Long id, User user) {
                       return "updated";
                   }
 
                   @DELETE
                   @Path("/users/{id}")
-                  public String deleteUser(@PathParam Long id) {
+                  public String deleteUser(@PathParam("id") Long id) {
                       return "deleted";
                   }
               }

--- a/src/test/java/org/openrewrite/quarkus/spring/WebToJaxRsTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/WebToJaxRsTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.quarkus.spring;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -259,6 +260,7 @@ class WebToJaxRsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/76")
     @Test
     void convertPathVariableWithoutExplicitValue() {
         rewriteRun(
@@ -296,6 +298,7 @@ class WebToJaxRsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/76")
     @Test
     void convertPathVariableWithNonValueAttributes() {
         rewriteRun(
@@ -370,6 +373,7 @@ class WebToJaxRsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/76")
     @Test
     void convertRequestParamWithoutExplicitValue() {
         rewriteRun(
@@ -406,6 +410,7 @@ class WebToJaxRsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/76")
     @Test
     void convertRequestHeaderWithoutExplicitValue() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/quarkus/spring/WebToJaxRsTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/WebToJaxRsTest.java
@@ -297,6 +297,42 @@ class WebToJaxRsTest implements RewriteTest {
     }
 
     @Test
+    void convertPathVariableWithNonValueAttributes() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.web.bind.annotation.*;
+
+              @RestController
+              public class UserController {
+
+                  @GetMapping("/users/{id}")
+                  public String getUser(@PathVariable(required = false) Long id) {
+                      return "user";
+                  }
+              }
+              """,
+            """
+              import jakarta.ws.rs.GET;
+              import jakarta.ws.rs.Path;
+              import jakarta.ws.rs.PathParam;
+
+              @Path("")
+              public class UserController {
+
+                  @GET
+                  @Path("/users/{id}")
+                  public String getUser(@PathParam("id") Long id) {
+                      return "user";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void convertRequestParam() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary
When Spring's `@PathVariable` is used without an explicit value, Spring infers the parameter name from the method parameter. JAX-RS's `@PathParam` requires an explicit value. This fix extracts the parameter name from the variable declaration when the annotation has no arguments.

The same issue is fixed for `@RequestParam` → `@QueryParam` and `@RequestHeader` → `@HeaderParam` conversions.

Tests updated to expect the inferred parameter names, and new test cases cover the scenario from the issue.