### PR TITLE
Remove Jackson BOM and allow rewrite-build-gradle-plugin to drive

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
 
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
-    implementation(platform("com.fasterxml.jackson:jackson-bom:2.21.0"))
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite:rewrite-xml")


### PR DESCRIPTION
## What's changed?

No need for a Jackson BOM here.