### PR TITLE
Fix AddProfile generating malformed XML (Issue #68)

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-native.yml
+++ b/src/main/resources/META-INF/rewrite/spring-native.yml
@@ -32,12 +32,16 @@ recipeList:
   - org.openrewrite.maven.AddProfile:
       id: native
       activation: |
-        <property>
-          <name>native</name>
-        </property>
+        <activation>
+          <property>
+            <name>native</name>
+          </property>
+        </activation>
       properties: |
-        <quarkus.native.enabled>true</quarkus.native.enabled>
-        <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+        <properties>
+          <quarkus.native.enabled>true</quarkus.native.enabled>
+          <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+        </properties>
   # Ensure quarkus-maven-plugin has native goals
   - org.openrewrite.quarkus.spring.AddQuarkusMavenPlugin
 
@@ -85,18 +89,26 @@ recipeList:
   - org.openrewrite.maven.AddProfile:
       id: native
       activation: |
-        <property>
-          <name>native</name>
-        </property>
+        <activation>
+          <property>
+            <name>native</name>
+          </property>
+        </activation>
       properties: |
-        <quarkus.package.type>native</quarkus.package.type>
-        <quarkus.native.enabled>true</quarkus.native.enabled>
+        <properties>
+          <quarkus.package.type>native</quarkus.package.type>
+          <quarkus.native.enabled>true</quarkus.native.enabled>
+        </properties>
   # Add container build profile for container-native builds
   - org.openrewrite.maven.AddProfile:
       id: container
       activation: |
-        <property>
-          <name>container</name>
-        </property>
+        <activation>
+          <property>
+            <name>container</name>
+          </property>
+        </activation>
       properties: |
-        <quarkus.container-image.build>true</quarkus.container-image.build>
+        <properties>
+          <quarkus.container-image.build>true</quarkus.container-image.build>
+        </properties>

--- a/src/test/java/org/openrewrite/quarkus/spring/ConfigureNativeBuildTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/ConfigureNativeBuildTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.spring;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+@Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/68")
+class ConfigureNativeBuildTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.quarkus.spring.ConfigureNativeBuild")
+          // AddProfile is not idempotent; it removes and re-adds the profile each cycle
+          .expectedCyclesThatMakeChanges(2);
+    }
+
+    @DocumentExample
+    @Test
+    void addNativeProfile() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>1.0.0</version>
+                  <profiles>
+                      <profile>
+                          <id>native</id>
+                          <activation>
+                              <property>
+                                  <name>native</name>
+                              </property>
+                          </activation>
+                          <properties>
+                              <quarkus.native.enabled>true</quarkus.native.enabled>
+                              <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+                          </properties>
+                      </profile>
+                  </profiles>
+              </project>
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/quarkus/spring/ConfigureNativeBuildTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/ConfigureNativeBuildTest.java
@@ -28,9 +28,7 @@ class ConfigureNativeBuildTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.openrewrite.quarkus.spring.ConfigureNativeBuild")
-          // AddProfile is not idempotent; it removes and re-adds the profile each cycle
-          .expectedCyclesThatMakeChanges(2);
+        spec.recipeFromResources("org.openrewrite.quarkus.spring.ConfigureNativeBuild");
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusPluginGoalsTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusPluginGoalsTest.java
@@ -26,9 +26,7 @@ class CustomizeQuarkusPluginGoalsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.openrewrite.quarkus.spring.CustomizeQuarkusPluginGoals")
-          // AddProfile is not idempotent; it removes and re-adds the profile each cycle
-          .expectedCyclesThatMakeChanges(2);
+        spec.recipeFromResources("org.openrewrite.quarkus.spring.CustomizeQuarkusPluginGoals");
     }
 
     @DocumentExample
@@ -82,42 +80,9 @@ class CustomizeQuarkusPluginGoalsTest implements RewriteTest {
     }
 
     @Test
-    void existingProfilesAreReplaced() {
+    void unchangedWhenProfilesAlreadyExist() {
         rewriteRun(
           pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>demo</artifactId>
-                  <version>1.0.0</version>
-                  <profiles>
-                      <profile>
-                          <id>native</id>
-                          <activation>
-                              <property>
-                                  <name>native</name>
-                              </property>
-                          </activation>
-                          <properties>
-                              <quarkus.package.type>native</quarkus.package.type>
-                              <quarkus.native.enabled>true</quarkus.native.enabled>
-                          </properties>
-                      </profile>
-                      <profile>
-                          <id>container</id>
-                          <activation>
-                              <property>
-                                  <name>container</name>
-                              </property>
-                          </activation>
-                          <properties>
-                              <quarkus.container-image.build>true</quarkus.container-image.build>
-                          </properties>
-                      </profile>
-                  </profiles>
-              </project>
-              """,
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>

--- a/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusPluginGoalsTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/CustomizeQuarkusPluginGoalsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.quarkus.spring;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -23,12 +22,13 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
-@Disabled("AddProfile is not idempotent and produces malformed XML")
 class CustomizeQuarkusPluginGoalsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.openrewrite.quarkus.spring.CustomizeQuarkusPluginGoals");
+        spec.recipeFromResources("org.openrewrite.quarkus.spring.CustomizeQuarkusPluginGoals")
+          // AddProfile is not idempotent; it removes and re-adds the profile each cycle
+          .expectedCyclesThatMakeChanges(2);
     }
 
     @DocumentExample
@@ -82,9 +82,42 @@ class CustomizeQuarkusPluginGoalsTest implements RewriteTest {
     }
 
     @Test
-    void doNotDuplicateExistingProfile() {
+    void existingProfilesAreReplaced() {
         rewriteRun(
           pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>1.0.0</version>
+                  <profiles>
+                      <profile>
+                          <id>native</id>
+                          <activation>
+                              <property>
+                                  <name>native</name>
+                              </property>
+                          </activation>
+                          <properties>
+                              <quarkus.package.type>native</quarkus.package.type>
+                              <quarkus.native.enabled>true</quarkus.native.enabled>
+                          </properties>
+                      </profile>
+                      <profile>
+                          <id>container</id>
+                          <activation>
+                              <property>
+                                  <name>container</name>
+                              </property>
+                          </activation>
+                          <properties>
+                              <quarkus.container-image.build>true</quarkus.container-image.build>
+                          </properties>
+                      </profile>
+                  </profiles>
+              </project>
+              """,
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Summary
- Added wrapping `<activation>` and `<properties>` elements to `AddProfile` parameters in `spring-native.yml` — the recipe expects these wrappers but they were missing, causing malformed XML output
- Removed `@Disabled` from `CustomizeQuarkusPluginGoalsTest` and added `ConfigureNativeBuildTest`

- Fixes #68

## Test plan
- [x] `CustomizeQuarkusPluginGoalsTest` passes (previously `@Disabled`)
- [x] New `ConfigureNativeBuildTest` verifies correct `<activation>` and `<properties>` structure
- [x] Full test suite passes (one pre-existing unrelated failure in `MigrateDatabaseDriversTest`)