### PR TITLE
Fix incorrect getId/setId removal and wrong PanacheEntity base class

### DIFF
--- a/src/main/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntity.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntity.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
@@ -38,6 +39,8 @@ public class JpaEntityToPanacheEntity extends Recipe {
     private static final String PANACHE_ENTITY_BASE_FQN = "io.quarkus.hibernate.orm.panache.PanacheEntityBase";
     private static final String ID_FQN = "jakarta.persistence.Id";
     private static final String GENERATED_VALUE_FQN = "jakarta.persistence.GeneratedValue";
+    private static final AnnotationMatcher ENTITY_MATCHER = new AnnotationMatcher("@" + ENTITY_FQN);
+    private static final AnnotationMatcher ID_MATCHER = new AnnotationMatcher("@" + ID_FQN);
 
     String displayName = "Convert JPA Entity to Panache Entity";
 
@@ -54,12 +57,7 @@ public class JpaEntityToPanacheEntity extends Recipe {
                         J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
 
                         // Check if class has @Entity annotation
-                        boolean hasEntityAnnotation = cd.getLeadingAnnotations().stream()
-                                .anyMatch(ann -> "Entity".equals(ann.getSimpleName()) ||
-                                        (ann.getAnnotationType().getType() != null &&
-                                                ENTITY_FQN.equals(ann.getAnnotationType().getType().toString())));
-
-                        if (!hasEntityAnnotation) {
+                        if (cd.getLeadingAnnotations().stream().noneMatch(ENTITY_MATCHER::matches)) {
                             return cd;
                         }
 
@@ -99,8 +97,8 @@ public class JpaEntityToPanacheEntity extends Recipe {
                                 Markers.EMPTY
                         ));
 
-                        // Only remove @Id field and getId/setId methods when the @Id field is named "id"
-                        if (idFieldNamedId) {
+                        // Only remove @Id field and getId/setId when PanacheEntity provides the id
+                        if (idFieldNamedId && isLongId) {
                             doAfterVisit(new RemoveIdFieldAndMethodsVisitor());
                         }
 
@@ -114,11 +112,7 @@ public class JpaEntityToPanacheEntity extends Recipe {
         for (org.openrewrite.java.tree.Statement stmt : cd.getBody().getStatements()) {
             if (stmt instanceof J.VariableDeclarations) {
                 J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
-                boolean hasIdAnnotation = vd.getLeadingAnnotations().stream()
-                        .anyMatch(ann -> "Id".equals(ann.getSimpleName()) ||
-                                (ann.getAnnotationType().getType() != null &&
-                                        ID_FQN.equals(ann.getAnnotationType().getType().toString())));
-                if (hasIdAnnotation) {
+                if (vd.getLeadingAnnotations().stream().anyMatch(ID_MATCHER::matches)) {
                     boolean isNamedId = vd.getVariables().stream()
                             .anyMatch(v -> "id".equals(v.getSimpleName()));
                     JavaType type = vd.getType();
@@ -149,13 +143,7 @@ public class JpaEntityToPanacheEntity extends Recipe {
         public J.@Nullable VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
             J.VariableDeclarations vd = super.visitVariableDeclarations(multiVariable, ctx);
 
-            // Check if this field has @Id annotation
-            boolean hasIdAnnotation = vd.getLeadingAnnotations().stream()
-                    .anyMatch(ann -> "Id".equals(ann.getSimpleName()) ||
-                            (ann.getAnnotationType().getType() != null &&
-                                    ID_FQN.equals(ann.getAnnotationType().getType().toString())));
-
-            if (hasIdAnnotation) {
+            if (vd.getLeadingAnnotations().stream().anyMatch(ID_MATCHER::matches)) {
                 boolean isIdField = vd.getVariables().stream()
                         .anyMatch(v -> "id".equals(v.getSimpleName()));
 

--- a/src/main/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntity.java
+++ b/src/main/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntity.java
@@ -35,6 +35,7 @@ public class JpaEntityToPanacheEntity extends Recipe {
 
     private static final String ENTITY_FQN = "jakarta.persistence.Entity";
     private static final String PANACHE_ENTITY_FQN = "io.quarkus.hibernate.orm.panache.PanacheEntity";
+    private static final String PANACHE_ENTITY_BASE_FQN = "io.quarkus.hibernate.orm.panache.PanacheEntityBase";
     private static final String ID_FQN = "jakarta.persistence.Id";
     private static final String GENERATED_VALUE_FQN = "jakarta.persistence.GeneratedValue";
 
@@ -67,34 +68,41 @@ public class JpaEntityToPanacheEntity extends Recipe {
                             String extendsType = cd.getExtends().getType() != null ?
                                     cd.getExtends().getType().toString() : "";
                             if (!extendsType.isEmpty() && !"java.lang.Object".equals(extendsType)) {
-                                // Already has a superclass, don't modify
                                 return cd;
                             }
                         }
 
-                        // Add PanacheEntity as superclass
-                        maybeAddImport(PANACHE_ENTITY_FQN);
+                        // Find the @Id field to determine type and name
+                        IdFieldInfo idFieldInfo = findIdField(cd);
+                        boolean isLongId = idFieldInfo != null && idFieldInfo.isLongType;
+                        boolean idFieldNamedId = idFieldInfo != null && idFieldInfo.isNamedId;
 
-                        // Create the extends identifier with proper spacing
+                        // Choose base class: PanacheEntity for Long id, PanacheEntityBase otherwise
+                        String panacheFqn = isLongId ? PANACHE_ENTITY_FQN : PANACHE_ENTITY_BASE_FQN;
+                        String panacheSimpleName = isLongId ? "PanacheEntity" : "PanacheEntityBase";
+
+                        maybeAddImport(panacheFqn);
+
                         J.Identifier panacheEntityId = new J.Identifier(
                                 Tree.randomId(),
-                                Space.SINGLE_SPACE,  // Space before "PanacheEntity" (after "extends")
+                                Space.SINGLE_SPACE,
                                 Markers.EMPTY,
                                 emptyList(),
-                                "PanacheEntity",
-                                JavaType.buildType(PANACHE_ENTITY_FQN),
+                                panacheSimpleName,
+                                JavaType.buildType(panacheFqn),
                                 null
                         );
 
-                        // Use padding to set proper extends clause with space before "extends"
                         cd = cd.getPadding().withExtends(new JLeftPadded<>(
-                                Space.SINGLE_SPACE,  // Space before "extends" keyword
+                                Space.SINGLE_SPACE,
                                 panacheEntityId,
                                 Markers.EMPTY
                         ));
 
-                        // Remove @Id field and its getter/setter
-                        doAfterVisit(new RemoveIdFieldAndMethodsVisitor());
+                        // Only remove @Id field and getId/setId methods when the @Id field is named "id"
+                        if (idFieldNamedId) {
+                            doAfterVisit(new RemoveIdFieldAndMethodsVisitor());
+                        }
 
                         return cd;
                     }
@@ -102,8 +110,38 @@ public class JpaEntityToPanacheEntity extends Recipe {
         );
     }
 
+    private static @Nullable IdFieldInfo findIdField(J.ClassDeclaration cd) {
+        for (org.openrewrite.java.tree.Statement stmt : cd.getBody().getStatements()) {
+            if (stmt instanceof J.VariableDeclarations) {
+                J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
+                boolean hasIdAnnotation = vd.getLeadingAnnotations().stream()
+                        .anyMatch(ann -> "Id".equals(ann.getSimpleName()) ||
+                                (ann.getAnnotationType().getType() != null &&
+                                        ID_FQN.equals(ann.getAnnotationType().getType().toString())));
+                if (hasIdAnnotation) {
+                    boolean isNamedId = vd.getVariables().stream()
+                            .anyMatch(v -> "id".equals(v.getSimpleName()));
+                    JavaType type = vd.getType();
+                    boolean isLongType = type != null && ("java.lang.Long".equals(type.toString()) || "long".equals(type.toString()));
+                    return new IdFieldInfo(isNamedId, isLongType);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static class IdFieldInfo {
+        final boolean isNamedId;
+        final boolean isLongType;
+
+        IdFieldInfo(boolean isNamedId, boolean isLongType) {
+            this.isNamedId = isNamedId;
+            this.isLongType = isLongType;
+        }
+    }
+
     /**
-     * Visitor to remove the @Id annotated field and its getter/setter since PanacheEntity provides the id.
+     * Visitor to remove the @Id annotated field named "id" and its getter/setter since PanacheEntity provides the id.
      */
     private static class RemoveIdFieldAndMethodsVisitor extends JavaIsoVisitor<ExecutionContext> {
 
@@ -118,7 +156,6 @@ public class JpaEntityToPanacheEntity extends Recipe {
                                     ID_FQN.equals(ann.getAnnotationType().getType().toString())));
 
             if (hasIdAnnotation) {
-                // Check if the field is named "id" - if so, remove it entirely
                 boolean isIdField = vd.getVariables().stream()
                         .anyMatch(v -> "id".equals(v.getSimpleName()));
 
@@ -136,7 +173,7 @@ public class JpaEntityToPanacheEntity extends Recipe {
         public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
 
-            // Remove getId() and setId() methods
+            // Only remove getId() and setId() when the @Id field is named "id"
             String methodName = m.getSimpleName();
             if ("getId".equals(methodName) || "setId".equals(methodName)) {
                 return null;

--- a/src/test/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntityTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntityTest.java
@@ -121,7 +121,7 @@ class JpaEntityToPanacheEntityTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/69")
     @Test
-    void doesNotRemoveGetIdWhenIdFieldNotNamedId() {
+    void removesIdFieldAndMethodsForLongIdWithOtherFields() {
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntityTest.java
+++ b/src/test/java/org/openrewrite/quarkus/spring/JpaEntityToPanacheEntityTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.quarkus.spring;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -73,6 +74,84 @@ class JpaEntityToPanacheEntityTest implements RewriteTest {
                   public void setName(String name) { this.name = name; }
                   public String getEmail() { return email; }
                   public void setEmail(String email) { this.email = email; }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/69")
+    @Test
+    void usesPanacheEntityBaseForStringId() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Id;
+
+              @Entity
+              public class Authority {
+                  @Id
+                  private String name;
+
+                  public String getId() {
+                      return this.name;
+                  }
+              }
+              """,
+            """
+              import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Id;
+
+              @Entity
+              public class Authority extends PanacheEntityBase {
+                  @Id
+                  private String name;
+
+                  public String getId() {
+                      return this.name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring-to-quarkus/issues/69")
+    @Test
+    void doesNotRemoveGetIdWhenIdFieldNotNamedId() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Id;
+              import jakarta.persistence.GeneratedValue;
+
+              @Entity
+              public class Item {
+                  @Id
+                  @GeneratedValue
+                  private Long id;
+
+                  private String code;
+
+                  public Long getId() { return id; }
+                  public void setId(Long id) { this.id = id; }
+                  public String getCode() { return code; }
+              }
+              """,
+            """
+              import io.quarkus.hibernate.orm.panache.PanacheEntity;
+              import jakarta.persistence.Entity;
+
+              @Entity
+              public class Item extends PanacheEntity {
+
+                  private String code;
+                  public String getCode() { return code; }
               }
               """
           )


### PR DESCRIPTION
## Summary

- Fixes #69

- Only remove `getId()`/`setId()` when the `@Id` field is actually named `id` (not unconditionally by method name)
- Use `PanacheEntityBase` when the `@Id` field type is not `Long`, since `PanacheEntity` assumes a `Long id`

## Test plan

- [x] Existing test continues to pass (Long id → PanacheEntity, removes getId/setId)
- [x] New test: String @Id field → uses PanacheEntityBase, preserves getId() and @Id field
- [x] New test: Long @Id field named "id" with other methods → still removes getId/setId correctly