### PR TITLE
Route Maven through Moderne Artifactory cache to avoid HTTP 429

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,38 @@ concurrency:
 
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
-    secrets:
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
-      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
+    steps:
+      - uses: openrewrite/gh-automation/.github/actions/setup@main
+        with:
+          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: ${{ secrets.ARTIFACTORY_USERNAME != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.ARTIFACTORY_USERNAME, secrets.ARTIFACTORY_PASSWORD) || '[]' }}
+
+      - uses: openrewrite/gh-automation/.github/actions/build@main
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
+
+      - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
+        with:
+          webhook: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+
+      - if: >
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main' &&
+          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
+        with:
+          sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+          sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
+          ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+          ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,56 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
+  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
+  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+
 jobs:
   release:
-    uses: openrewrite/gh-automation/.github/workflows/publish-gradle.yml@main
-    secrets:
-      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
-      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openrewrite/gh-automation/.github/actions/setup@main
+        with:
+          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: ${{ secrets.ARTIFACTORY_USERNAME != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.ARTIFACTORY_USERNAME, secrets.ARTIFACTORY_PASSWORD) || '[]' }}
+
+      - name: publish-candidate
+        if: contains(github.ref, '-rc.')
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
+        run: |
+          ./gradlew \
+          ${{ env.GRADLE_SWITCHES }} \
+          -Preleasing \
+          -Prelease.disableGitChecks=true \
+          -Prelease.useLastTag=true \
+          candidate \
+          publish \
+          closeAndReleaseSonatypeStagingRepository
+
+      - name: publish-release
+        if: (!contains(github.ref, '-rc.'))
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
+        run: |
+          ./gradlew \
+          ${{ env.GRADLE_SWITCHES }} \
+          -Preleasing \
+          -Prelease.disableGitChecks=true \
+          -Prelease.useLastTag=true \
+          final \
+          publish \
+          closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
## Summary
- CI failed today with `https://repo.maven.apache.org/maven2: HTTP 429` — Maven Central is rate-limiting parallel test resolution.
- Inline the same mirror configuration that `moderneinc/rewrite-java-security` uses successfully today: route all Maven resolution through `https://artifactory.moderne.ninja/artifactory/moderne-cache-3/` via `s4u/maven-settings-action`, and set `REWRITE_GRADLE_MIRROR_*` env vars on the Gradle build / publish steps.
- Replaces the thin call into `openrewrite/gh-automation`'s reusable `ci-gradle.yml` / `publish-gradle.yml` with their composite actions invoked inline — the bypass pattern the reusable workflow explicitly recommends for consumers that need a mirror.
- Validated by the pilot PR moderneinc/rewrite-dropwizard#14, which built green in 4m16s with no 429s.

## Test plan
- [ ] PR CI passes
- [ ] Build logs show `s4u/maven-settings-action` step ran
- [ ] No `HTTP 429` lines in build logs